### PR TITLE
Configure automatic deploys on Heroku

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,14 @@ language: python
 cache: pip
 
 python:
-  - '3.6'
+  - "3.6"
 
 services:
   - postgresql
 
 addons:
   # Django 2.1+ requires PostgreSQL 9.4+
-  postgresql: '9.4'
+  postgresql: "9.4"
 
 install:
   - pip install -r requirements.txt
@@ -32,20 +32,3 @@ before_script:
 
 script:
   - python manage.py test
-
-deploy:
-  # Deploy to Heroku once the tests have passed
-  # See TravisCI docs: https://docs.travis-ci.com/user/deployment/heroku/
-  provider: heroku
-  app:
-    # direct each branch to the corresponding app
-    master: oser-backend
-    dev: oser-backend-dev
-  run:
-    # automatically run new migrations
-    - 'python manage.py migrate'
-  api_key:
-    # Encrypted API key obtained from the following command
-    # (requires TravisCI and Heroku CLI installed)
-    # $ travis encrypt $(heroku auth:token) --add deploy.api_key
-    secure: tk6Pfrftlma+m6TYwl3DODf4rrtoPbvL5C94rBWEyjE3ttyitFIMqWAhG/lVR83ZmCd+sGvm250fqKes2+ZINYW92csvu9vngG4018qzDJ0agA2wOsNkn+mMih96hk+uWpRHWZ90BDG/wWcWnquSzS2fNNmdJVS5lEH4lPQBrgN0dTlHROHnFn5eJK7BR/22EOfF2wmREdMohn7QDBalju+C5ywGKNVYJ9Lhychlp/LbemrHViIXheCO3dS0Lu+AsQaH0Gh+793tmHWqRJhY4EP0IKi6xguH9/b80hkgAH8zZYo8HOXCGBUJnTNWJsf5H4Dvcoeny0p6ak/oyudwO/ZEQB0bs5MeAa5yCunEb6nCnpmPy+spvVjK3ZSGLhfetYHn44tApzFNnqOJPnHSFHy0Tbi/RDFpH6998iUWx7MbXsjsxLnj1C/c53l5xg9YxbZKp8YBNlmwMKdBaEnZEiHyVBhJG05JVnacMUAajtOisObG2yKBjcgUxNuTRIFlSj8UKKlF+wnjrRQLGHK32ISkE+g4NAePtqU5W4hjKqpMvv9uNEopkGb9XNo+9PWN168s7trKWcLIaqNykAVS/0LUYomuV2tMdIcP7biYO84r1YRmFFblTIb19vFsQNagRRZ27gFnjozPufVmDF8tp3buEeEkRTDZZIcJfoGoJFM=

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,2 @@
+release: python manage.py migrate --noinput
 web: gunicorn oser_backend.wsgi:application --bind 0.0.0.0:$PORT


### PR DESCRIPTION
Les déploiements sur `master` et `dev` ont planté à l'instant parce que la clé d'API que j'avais chiffrée dans le `.travis.yml` n'était plus à jour (j'ai changé mon mdp entre temps).

Je me suis dit que c'était moyen comme situation donc j'ai fait comme dans le front : j'ai configuré le déploiement automatique via le dashboard Heroku.

Je pense qu'à l'époque j'avais fait comme ça pour pouvoir lancer le `python manage.py migrate` après le déploiement, mais maintenant il y a une option dans le `Procfile` pour ça : [Release phase tasks](https://devcenter.heroku.com/articles/release-phase#specifying-release-phase-tasks).